### PR TITLE
Fix stack misalignment issue on saved thread state

### DIFF
--- a/OperatingSystem/source/threading/scheduler.cpp
+++ b/OperatingSystem/source/threading/scheduler.cpp
@@ -90,6 +90,8 @@ void scheduler::thread_exit()
 static void save_thread_state(const interrupts::interrupt_frame& frame) 
 {
 	current_thread_state->regs = frame.regs;
+	// shift the stack position by 20 bytes to compensate for the five DWORD registers (eip, cs, eflags, sp, ss) the CPU put on the stack
+	current_thread_state->regs.esp += 20;
 	current_thread_state->eip = frame.eip;
 	current_thread_state->eflags = frame.eflags;
 }


### PR DESCRIPTION
When saving the thread state, the code did not account for the five registers (eip, cs, eflags, sp, ss) that the CPU automatically pushes to the stack as part of the interrupt. Since the registers are pushed to the stack before the pushad in `isr_common_stub`, the saved esp value is incorrect and offset by 20 bytes. This is why each thread context switch resulted in one thread's stack position being shifted by -0x14. The ultimate consequence of this was a crash after the thread stacks grew downwards far enough to interfere with the kernel stack.

The fix is simple: we can just add 20 to the saved esp value in `save_thread_state` to compensate for this offset.

The kernel stack should not be affected by this issue when processing other ISRs, because the five registers are encapsulated by the `interrupt_frame` struct and the compiler emits the correct assembly in the function epilogue to clean up the stack when the function returns. It's only because we're capturing the shifted stack value before the epilogue executes that this bug arose.